### PR TITLE
rehaul UI for readability of blogs

### DIFF
--- a/app/Main.tsx
+++ b/app/Main.tsx
@@ -13,7 +13,7 @@ export default function Home({ posts }) {
       <div className="mt-7 justify-between space-y-4">
         <div className="flex flex-col md:flex-row">
           <div id="div1" className="mb-4 text-left md:mb-0 md:basis-1/2">
-            <h1 className="text-3xl font-extrabold leading-none tracking-tight text-gray-900 dark:text-gray-100 sm:text-4xl sm:leading-none md:text-5xl md:leading-tight lg:text-6xl lg:leading-none">
+            <h1 className="font-display text-3xl font-bold leading-none tracking-tight text-gray-900 dark:text-gray-100 sm:text-4xl sm:leading-none md:text-5xl md:leading-tight lg:text-6xl lg:leading-none">
               hi, <span>i'm </span>
               <span className="whitespace-nowrap text-primary-500 dark:text-primary-300">
                 shashank shekhar
@@ -53,7 +53,7 @@ export default function Home({ posts }) {
       </div>
       <div className="divide-y divide-gray-200 pt-2 dark:divide-gray-700">
         <div className="mt-4 space-y-2 pb-2 pt-6 md:mt-0 md:space-y-4">
-          <h2 className="text-2xl font-extrabold leading-none tracking-tight text-gray-900 dark:text-gray-100 sm:text-3xl sm:leading-none md:text-4xl md:leading-none">
+          <h2 className="font-display text-xl font-bold leading-none tracking-tight text-gray-900 dark:text-gray-100 sm:text-2xl sm:leading-none md:text-3xl md:leading-none">
             Latest Posts
           </h2>
           <p className="text-lg leading-7 text-gray-500 dark:text-gray-400">
@@ -70,7 +70,7 @@ export default function Home({ posts }) {
                   <div className="space-y-2 xl:grid xl:grid-cols-4 xl:items-baseline xl:space-y-0">
                     <dl>
                       <dt className="sr-only">Published on</dt>
-                      <dd className="text-base font-medium leading-6 text-gray-500 dark:text-gray-400">
+                      <dd className="text-sm font-normal leading-6 text-gray-400 dark:text-gray-500">
                         <time dateTime={date}>{formatDate(date, siteMetadata.locale)}</time>
                       </dd>
                     </dl>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,7 +2,7 @@ import 'css/tailwind.css'
 import 'pliny/search/algolia.css'
 import 'rehype-callouts/theme/obsidian'
 
-import { Space_Grotesk } from 'next/font/google'
+import { Inter, Space_Grotesk } from 'next/font/google'
 import { Analytics, AnalyticsConfig } from 'pliny/analytics'
 import { SearchConfig } from 'pliny/search'
 import { SearchProvider } from '@/components/Search'
@@ -12,6 +12,12 @@ import Footer from '@/components/Footer'
 import siteMetadata from '@/data/siteMetadata'
 import { ThemeProviders } from './theme-providers'
 import { Metadata } from 'next'
+
+const inter = Inter({
+  subsets: ['latin'],
+  display: 'swap',
+  variable: '--font-inter',
+})
 
 const space_grotesk = Space_Grotesk({
   subsets: ['latin'],
@@ -63,7 +69,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html
       lang={siteMetadata.language}
-      className={`${space_grotesk.variable} scroll-smooth`}
+      className={`${inter.variable} ${space_grotesk.variable} scroll-smooth`}
       suppressHydrationWarning
     >
       <link rel="apple-touch-icon" sizes="76x76" href="/static/favicons/apple-touch-icon.png" />
@@ -75,7 +81,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <meta name="theme-color" media="(prefers-color-scheme: light)" content="#fff" />
       <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#000" />
       <link rel="alternate" type="application/rss+xml" href="/feed.xml" />
-      <body className="bg-white pl-[calc(100vw-100%)] text-black antialiased dark:bg-gray-950 dark:text-white">
+      <body className="bg-sepia-50 pl-[calc(100vw-100%)] text-black antialiased dark:bg-gray-950 dark:text-white">
         <ThemeProviders>
           <Analytics analyticsConfig={siteMetadata.analytics as AnalyticsConfig} />
           <SectionContainer>

--- a/components/PageTitle.tsx
+++ b/components/PageTitle.tsx
@@ -6,7 +6,7 @@ interface Props {
 
 export default function PageTitle({ children }: Props) {
   return (
-    <h1 className="text-3xl font-extrabold leading-9 tracking-tight text-gray-900 dark:text-gray-100 sm:text-4xl sm:leading-10 md:text-5xl md:leading-14">
+    <h1 className="font-display text-2xl font-bold leading-9 tracking-tight text-gray-900 dark:text-gray-100 sm:text-3xl sm:leading-10 md:text-4xl md:leading-14">
       {children}
     </h1>
   )

--- a/components/Tag.tsx
+++ b/components/Tag.tsx
@@ -8,7 +8,7 @@ const Tag = ({ text }: Props) => {
   return (
     <Link
       href={`/tags/${slug(text)}`}
-      className="mr-3 text-sm font-medium uppercase text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
+      className="mr-3 text-sm font-normal text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
     >
       {text.split(' ').join('-')}
     </Link>

--- a/components/ThemeSwitch.tsx
+++ b/components/ThemeSwitch.tsx
@@ -1,45 +1,79 @@
 // Source: https://github.com/dlarroder/dalelarroder/blob/main/components/ThemeSwitch.tsx
 'use client'
 
-import { motion } from 'framer-motion'
+import { AnimatePresence, motion } from 'framer-motion'
 import { useTheme } from 'next-themes'
 import { useEffect, useState } from 'react'
 import { BsMoonFill, BsSunFill } from 'react-icons/bs'
 
 const ThemeSwitch = () => {
   const [mounted, setMounted] = useState(false)
+  const [scrolled, setScrolled] = useState(false)
   const { theme, setTheme, resolvedTheme } = useTheme()
 
-  // When mounted on client, now we can show the UI
   useEffect(() => setMounted(true), [])
 
+  useEffect(() => {
+    const handleScroll = () => {
+      setScrolled(window.scrollY > 50)
+    }
+    window.addEventListener('scroll', handleScroll)
+    return () => window.removeEventListener('scroll', handleScroll)
+  }, [])
+
+  const isDark = mounted && (theme === 'dark' || resolvedTheme === 'dark')
+  const toggleTheme = () => setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')
+
+  const icon = isDark ? <BsSunFill size={16} /> : <BsMoonFill size={18} />
+
   return (
-    <motion.button
-      id="theme-btn"
-      aria-label="Toggle Dark Mode"
-      type="button"
-      className="ml-1 mr-1 h-8 w-8 rounded p-1"
-      whileTap={{
-        scale: 0.7,
-        rotate: 360,
-        transition: { duration: 0.2 },
-      }}
-      whileHover={{ scale: 1.2 }}
-      onClick={() => setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')}
-    >
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 20 20"
-        fill="currentColor"
-        className="text-gray-900 dark:text-gray-100"
+    <>
+      {/* Inline button in the header — hidden when scrolled */}
+      <motion.button
+        id="theme-btn"
+        aria-label="Toggle Dark Mode"
+        type="button"
+        className={`ml-1 mr-1 h-8 w-8 rounded p-1 ${scrolled ? 'invisible' : 'visible'}`}
+        whileTap={{ scale: 0.7, rotate: 360, transition: { duration: 0.2 } }}
+        whileHover={{ scale: 1.2 }}
+        onClick={toggleTheme}
       >
-        {mounted && (theme === 'dark' || resolvedTheme === 'dark') ? (
-          <BsSunFill size={16} />
-        ) : (
-          <BsMoonFill size={18} />
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+          className="text-gray-900 dark:text-gray-100"
+        >
+          {icon}
+        </svg>
+      </motion.button>
+
+      {/* Floating button — appears when scrolled past header */}
+      <AnimatePresence>
+        {scrolled && (
+          <motion.button
+            key="floating-theme-btn"
+            aria-label="Toggle Dark Mode"
+            type="button"
+            className="fixed right-8 top-8 z-50 hidden rounded-full bg-gray-200 p-2 text-gray-500 shadow-md transition-colors hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600 md:block"
+            initial={{ opacity: 0, scale: 0.6 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.6 }}
+            transition={{ duration: 0.2 }}
+            onClick={toggleTheme}
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+              className="h-5 w-5"
+            >
+              {icon}
+            </svg>
+          </motion.button>
         )}
-      </svg>
-    </motion.button>
+      </AnimatePresence>
+    </>
   )
 }
 

--- a/components/sidetoc/TocBody.tsx
+++ b/components/sidetoc/TocBody.tsx
@@ -35,7 +35,9 @@ const TocBody = ({ toc }: TocBodyProps) => {
     <div className="fixed left-0 top-0 z-50 h-screen md:flex">
       <div className="sticky left-0 top-0 z-50 flex h-screen w-64 flex-col overflow-y-auto bg-gray-100 px-2 py-4 dark:bg-gray-800">
         <div className="mb-20 mt-20">
-          <div className="text-base font-semibold text-gray-900 dark:text-gray-100">Table of Contents</div>
+          <div className="text-base font-semibold text-gray-900 dark:text-gray-100">
+            Table of Contents
+          </div>
           <div className="my-auto mt-5 overflow-y-auto">
             <TOCInline
               toc={filteredToc}

--- a/components/sidetoc/TocBody.tsx
+++ b/components/sidetoc/TocBody.tsx
@@ -35,12 +35,12 @@ const TocBody = ({ toc }: TocBodyProps) => {
     <div className="fixed left-0 top-0 z-50 h-screen md:flex">
       <div className="sticky left-0 top-0 z-50 flex h-screen w-64 flex-col overflow-y-auto bg-gray-100 px-2 py-4 dark:bg-gray-800">
         <div className="mb-20 mt-20">
-          <div className="text-heading-400 text-xl font-bold">Table of Contents</div>
+          <div className="text-base font-semibold text-gray-900 dark:text-gray-100">Table of Contents</div>
           <div className="my-auto mt-5 overflow-y-auto">
             <TOCInline
               toc={filteredToc}
-              ulClassName="space-y-2 overflow-y-auto my-auto text-primary-500"
-              liClassName="pl-3 hover:text-heading-400"
+              ulClassName="list-disc pl-4 space-y-1 text-sm text-gray-700 dark:text-gray-300 [&_ul]:ml-3 [&_ul]:list-[circle] [&_ul_ul]:list-[square]"
+              liClassName="py-0.5 hover:text-primary-500 dark:hover:text-primary-400"
             />
           </div>
         </div>

--- a/css/prism.css
+++ b/css/prism.css
@@ -1,17 +1,22 @@
 /**
  * CSS Styles for code highlighting.
- * Feel free to customize token styles 
+ * Feel free to customize token styles
  * by copying from a prismjs compatible theme:
  * https://github.com/PrismJS/prism-themes
  */
 
 /* Code title styles */
 .remark-code-title {
-  @apply rounded-t bg-gray-700 px-5 py-3 font-mono text-sm font-bold text-gray-200 dark:bg-gray-800;
+  @apply rounded-t bg-gray-100 px-5 py-3 font-mono text-sm font-bold text-gray-800 dark:bg-gray-800 dark:text-gray-200;
 }
 
 .remark-code-title + div > pre {
   @apply mt-0 rounded-t-none;
+}
+
+/* Subtle border for code blocks */
+.prose :where(pre):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+  @apply rounded-lg border-2 border-gray-300 dark:border dark:border-gray-700;
 }
 
 /* Code block styles */
@@ -31,78 +36,85 @@
   @apply bg-red-500 bg-opacity-20;
 }
 
+/* Highlight line — light mode */
 .highlight-line {
-  @apply -mx-4 border-l-4 border-primary-500 bg-gray-700 bg-opacity-50;
+  @apply -mx-4 border-l-4 border-sky-400 bg-sky-50;
+}
+
+/* Highlight line — dark mode */
+.dark .highlight-line {
+  @apply bg-gray-700 bg-opacity-50;
 }
 
 .line-number::before {
-  @apply -ml-2 mr-4 inline-block w-4 text-right text-gray-400;
+  @apply -ml-2 mr-4 inline-block w-4 text-right;
   content: attr(line);
+  color: #9ca3af; /* gray-400 */
 }
 
-/* Token styles */
-/**
- * MIT License
- * Copyright (c) 2018 Sarah Drasner
- * Sarah Drasner's[@sdras] Night Owl
- * Ported by Sara vieria [@SaraVieira]
- * Added by Souvik Mandal [@SimpleIndian]
- */
+.dark .line-number::before {
+  color: #6b7280; /* gray-500 for dark bg */
+}
+
+/* ==========================================================================
+   Light mode token styles — GitHub-inspired light theme
+   ========================================================================== */
+
 .token.comment,
 .token.prolog,
 .token.cdata {
-  color: rgb(99, 119, 119);
+  color: #6a737d;
   font-style: italic;
 }
 
 .token.punctuation {
-  color: rgb(199, 146, 234);
+  color: #24292e;
 }
 
 .namespace {
-  color: rgb(178, 204, 214);
+  color: #6f42c1;
 }
 
 .token.deleted {
-  color: rgba(239, 83, 80, 0.56);
+  color: #b31d28;
   font-style: italic;
 }
 
 .token.symbol,
 .token.property {
-  color: rgb(128, 203, 196);
+  color: #005cc5;
 }
 
 .token.tag,
 .token.operator,
 .token.keyword {
-  color: rgb(127, 219, 202);
+  color: #d73a49;
 }
 
 .token.boolean {
-  color: rgb(255, 88, 116);
+  color: #005cc5;
 }
 
 .token.number {
-  color: rgb(247, 140, 108);
+  color: #005cc5;
 }
 
 .token.constant,
 .token.function,
 .token.builtin,
 .token.char {
-  color: rgb(130, 170, 255);
+  color: #6f42c1;
 }
 
 .token.selector,
 .token.doctype {
-  color: rgb(199, 146, 234);
+  color: #6f42c1;
   font-style: italic;
 }
 
 .token.attr-name,
 .token.inserted {
-  color: rgb(173, 219, 103);
+  color: #22863a;
   font-style: italic;
 }
 
@@ -111,19 +123,19 @@
 .token.entity,
 .language-css .token.string,
 .style .token.string {
-  color: rgb(173, 219, 103);
+  color: #032f62;
 }
 
 .token.class-name,
 .token.atrule,
 .token.attr-value {
-  color: rgb(255, 203, 139);
+  color: #e36209;
 }
 
 .token.regex,
 .token.important,
 .token.variable {
-  color: rgb(214, 222, 235);
+  color: #24292e;
 }
 
 .token.important,
@@ -139,6 +151,87 @@
   display: inline;
 }
 
-.token.table {
-  display: inline;
+/* ==========================================================================
+   Dark mode token styles — Night Owl by Sarah Drasner
+   MIT License, Copyright (c) 2018 Sarah Drasner
+   Ported by Sara Vieira [@SaraVieira]
+   Added by Souvik Mandal [@SimpleIndian]
+   ========================================================================== */
+
+.dark .token.comment,
+.dark .token.prolog,
+.dark .token.cdata {
+  color: rgb(99, 119, 119);
+  font-style: italic;
+}
+
+.dark .token.punctuation {
+  color: rgb(199, 146, 234);
+}
+
+.dark .namespace {
+  color: rgb(178, 204, 214);
+}
+
+.dark .token.deleted {
+  color: rgba(239, 83, 80, 0.56);
+  font-style: italic;
+}
+
+.dark .token.symbol,
+.dark .token.property {
+  color: rgb(128, 203, 196);
+}
+
+.dark .token.tag,
+.dark .token.operator,
+.dark .token.keyword {
+  color: rgb(127, 219, 202);
+}
+
+.dark .token.boolean {
+  color: rgb(255, 88, 116);
+}
+
+.dark .token.number {
+  color: rgb(247, 140, 108);
+}
+
+.dark .token.constant,
+.dark .token.function,
+.dark .token.builtin,
+.dark .token.char {
+  color: rgb(130, 170, 255);
+}
+
+.dark .token.selector,
+.dark .token.doctype {
+  color: rgb(199, 146, 234);
+  font-style: italic;
+}
+
+.dark .token.attr-name,
+.dark .token.inserted {
+  color: rgb(173, 219, 103);
+  font-style: italic;
+}
+
+.dark .token.string,
+.dark .token.url,
+.dark .token.entity,
+.dark .language-css .token.string,
+.dark .style .token.string {
+  color: rgb(173, 219, 103);
+}
+
+.dark .token.class-name,
+.dark .token.atrule,
+.dark .token.attr-value {
+  color: rgb(255, 203, 139);
+}
+
+.dark .token.regex,
+.dark .token.important,
+.dark .token.variable {
+  color: rgb(214, 222, 235);
 }

--- a/css/prism.css
+++ b/css/prism.css
@@ -15,7 +15,7 @@
 }
 
 /* Subtle border for code blocks */
-.prose :where(pre):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+.prose :where(pre):not(:where([class~='not-prose'], [class~='not-prose'] *)) {
   @apply rounded-lg border-2 border-gray-300 dark:border dark:border-gray-700;
 }
 

--- a/layouts/ListLayoutWithTags.tsx
+++ b/layouts/ListLayoutWithTags.tsx
@@ -82,7 +82,7 @@ export default function ListLayoutWithTags({
     <>
       <div>
         <div className="pb-6 pt-6">
-          <h1 className="text-3xl font-extrabold leading-9 tracking-tight text-gray-900 dark:text-gray-100 sm:hidden sm:text-4xl sm:leading-10 md:text-6xl md:leading-14">
+          <h1 className="font-display text-2xl font-bold leading-9 tracking-tight text-gray-900 dark:text-gray-100 sm:hidden sm:text-3xl sm:leading-10 md:text-5xl md:leading-14">
             {title}
           </h1>
         </div>
@@ -90,11 +90,11 @@ export default function ListLayoutWithTags({
           <div className="hidden h-full max-h-screen min-w-[280px] max-w-[280px] flex-wrap overflow-auto rounded bg-gray-50 pt-5 shadow-md dark:bg-gray-900/70 dark:shadow-gray-800/40 sm:flex">
             <div className="px-6 py-4">
               {pathname.startsWith('/blog') ? (
-                <h3 className="font-bold uppercase text-primary-500">All Posts</h3>
+                <h3 className="font-bold text-gray-900 dark:text-gray-100">All Posts</h3>
               ) : (
                 <Link
                   href={`/blog`}
-                  className="font-bold uppercase text-gray-700 hover:text-primary-500 dark:text-gray-300 dark:hover:text-primary-500"
+                  className="font-bold text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100"
                 >
                   All Posts
                 </Link>
@@ -104,13 +104,13 @@ export default function ListLayoutWithTags({
                   return (
                     <li key={t} className="my-3">
                       {pathname.split('/tags/')[1] === slug(t) ? (
-                        <h3 className="inline px-3 py-2 text-sm font-bold uppercase text-primary-500">
+                        <h3 className="inline px-3 py-2 text-sm font-bold text-gray-900 dark:text-gray-100">
                           {`${t} (${tagCounts[t]})`}
                         </h3>
                       ) : (
                         <Link
                           href={`/tags/${slug(t)}`}
-                          className="px-3 py-2 text-sm font-medium uppercase text-gray-500 hover:text-primary-500 dark:text-gray-300 dark:hover:text-primary-500"
+                          className="px-3 py-2 text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-gray-100"
                           aria-label={`View posts tagged ${t}`}
                         >
                           {`${t} (${tagCounts[t]})`}
@@ -131,7 +131,7 @@ export default function ListLayoutWithTags({
                     <article className="flex flex-col space-y-2 xl:space-y-0">
                       <dl>
                         <dt className="sr-only">Published on</dt>
-                        <dd className="text-base font-medium leading-6 text-gray-500 dark:text-gray-400">
+                        <dd className="text-sm font-normal leading-6 text-gray-400 dark:text-gray-500">
                           <time dateTime={date}>{formatDate(date, siteMetadata.locale)}</time>
                           <span className="mx-2">|</span>
                           <span>Views: {totalViews}</span>

--- a/layouts/PostBanner.tsx
+++ b/layouts/PostBanner.tsx
@@ -45,7 +45,7 @@ export default function PostMinimal({ content, next, prev, children }: LayoutPro
               <PageTitle>{title}</PageTitle>
             </div>
           </div>
-          <div className="prose max-w-none py-4 dark:prose-invert">{children}</div>
+          <div className="prose py-4 dark:prose-invert">{children}</div>
           {siteMetadata.comments && (
             <div className="pb-6 pt-6 text-center text-gray-700 dark:text-gray-300" id="comment">
               <Comments slug={slug} />

--- a/layouts/PostLayout.tsx
+++ b/layouts/PostLayout.tsx
@@ -56,7 +56,7 @@ export default function PostLayout({
               <dl className="space-y-10">
                 <div>
                   <dt className="sr-only">Published on</dt>
-                  <dd className="text-base font-medium leading-6 text-gray-500 dark:text-gray-400">
+                  <dd className="text-sm font-normal leading-6 text-gray-400 dark:text-gray-500">
                     <time dateTime={date}>
                       {new Date(date).toLocaleDateString(siteMetadata.locale, postDateTemplate)}
                     </time>
@@ -116,7 +116,7 @@ export default function PostLayout({
               </dd>
             </dl>
             <div className="divide-y divide-gray-200 dark:divide-gray-700 xl:col-span-3 xl:row-span-2 xl:pb-0">
-              <div className="prose max-w-none pb-8 pt-10 dark:prose-invert">{children}</div>
+              <div className="prose pb-8 pt-10 dark:prose-invert">{children}</div>
               <div className="pb-6 pt-6 text-sm text-gray-700 dark:text-gray-300">
                 <Link href={discussUrl(path)} rel="nofollow">
                   Discuss on Twitter

--- a/layouts/PostSimple.tsx
+++ b/layouts/PostSimple.tsx
@@ -36,7 +36,7 @@ export default function PostLayout({ content, next, totalViews, prev, children }
               <dl>
                 <div>
                   <dt className="sr-only">Published on</dt>
-                  <dd className="text-base font-medium leading-6 text-gray-500 dark:text-gray-400">
+                  <dd className="text-sm font-normal leading-6 text-gray-400 dark:text-gray-500">
                     <time dateTime={date}>{formatDate(date, siteMetadata.locale)}</time>
                     <span className="mx-2">|</span>
                     <span>Views: {totalViews}</span>
@@ -57,7 +57,7 @@ export default function PostLayout({ content, next, totalViews, prev, children }
           </header>
           <div className="grid-rows-[auto_1fr] divide-y divide-gray-200 pb-8 dark:divide-gray-700 xl:divide-y-0">
             <div className="divide-y divide-gray-200 dark:divide-gray-700 xl:col-span-3 xl:row-span-2 xl:pb-0">
-              <div className="prose max-w-none pb-8 pt-10 dark:prose-invert">{children}</div>
+              <div className="prose pb-8 pt-10 dark:prose-invert">{children}</div>
             </div>
             {siteMetadata.comments && (
               <div className="pb-6 pt-6 text-center text-gray-700 dark:text-gray-300" id="comment">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -22,15 +22,35 @@ module.exports = {
         14: '3.5rem',
       },
       fontFamily: {
-        sans: ['var(--font-space-grotesk)', ...fontFamily.sans],
+        sans: ['var(--font-inter)', ...fontFamily.sans],
+        display: ['var(--font-space-grotesk)', ...fontFamily.sans],
       },
       colors: {
-        primary: colors.pink,
+        primary: {
+          50: '#fdf2f8',
+          100: '#fce7f3',
+          200: '#f9c6e3',
+          300: '#f49fcf',
+          400: '#e06aaf',
+          500: '#c71585',
+          600: '#ad1274',
+          700: '#8f0f5f',
+          800: '#750e4e',
+          900: '#621143',
+          950: '#3b0524',
+        },
         gray: colors.gray,
+        sepia: {
+          50: '#faf8f5',
+          100: '#f5f0eb',
+        },
       },
       typography: ({ theme }) => ({
         DEFAULT: {
           css: {
+            fontSize: '1rem',
+            lineHeight: '1.75',
+            maxWidth: '680px',
             a: {
               color: theme('colors.primary.500'),
               '&:hover': {
@@ -38,12 +58,51 @@ module.exports = {
               },
               code: { color: theme('colors.primary.400') },
             },
+            'h1,h2,h3,h4,h5,h6': {
+              fontFamily: theme('fontFamily.display').join(', '),
+            },
             'h1,h2': {
               fontWeight: '700',
               letterSpacing: theme('letterSpacing.tight'),
             },
+            h1: {
+              fontSize: '1.75rem',
+              marginTop: '2em',
+              marginBottom: '0.75em',
+            },
+            h2: {
+              fontSize: '1.375rem',
+              marginTop: '2em',
+              marginBottom: '0.75em',
+            },
             h3: {
               fontWeight: '600',
+              fontSize: '1.125rem',
+              marginTop: '1.75em',
+              marginBottom: '0.5em',
+            },
+            h4: {
+              fontSize: '1rem',
+              marginTop: '1.5em',
+              marginBottom: '0.5em',
+            },
+            p: {
+              marginTop: '1.25em',
+              marginBottom: '1.25em',
+            },
+            pre: {
+              marginTop: '1.75em',
+              marginBottom: '1.75em',
+              backgroundColor: theme('colors.gray.100'),
+              color: theme('colors.gray.800'),
+            },
+            img: {
+              marginTop: '2em',
+              marginBottom: '2em',
+            },
+            table: {
+              marginTop: '1.5em',
+              marginBottom: '1.5em',
             },
             code: {
               color: theme('colors.indigo.500'),
@@ -61,6 +120,10 @@ module.exports = {
             },
             'h1,h2,h3,h4,h5,h6': {
               color: theme('colors.gray.100'),
+            },
+            pre: {
+              backgroundColor: '#011627',
+              color: '#d6deeb',
             },
           },
         },


### PR DESCRIPTION
## Typography & Readability Overhaul

A comprehensive restyle of the blog's typography, color palette, and visual chrome to improve readability for long-form technical content. Inspired by the clean, content-forward design of blogs like Lilian Weng's and Simon Boehm's.

### Font & Typography
- **Body font**: Switched from Space Grotesk (geometric display sans) to **Inter** (humanist sans-serif optimized for screen reading)
- **Display font**: Space Grotesk retained for headings, site title, and navigation via `font-display` utility
- **Font size**: Body text set to 16px (down from 18px default) with 1.75 line-height
- **Prose width**: Constrained to 680px max for ~65-75 characters per line
- **Heading hierarchy**: Graceful scaling — PageTitle (24-36px responsive) > H1 (28px) > H2 (22px) > H3 (18px) > H4 (16px)
- **Spacing**: Increased whitespace around paragraphs, code blocks, images, and section headings

### Color & Accents
- **Primary color**: Custom maroon-pink palette built around `#C71585` (matching the site logo), replacing the original hot pink
- **Background**: Subtle warm sepia tint (`#faf8f5`) in light mode for a book-like reading feel; dark mode unchanged
- **Tags**: Switched from uppercase pink to lowercase neutral gray — scannable but not attention-competing
- **Metadata**: Reduced visual weight (smaller, lighter text) for dates, view counts, and reading time

### Code Blocks
- **Light theme**: GitHub-inspired light syntax colors when site is in light mode (light background, dark-on-light tokens)
- **Dark theme**: Night Owl theme retained for dark mode, scoped under `.dark`
- **Borders**: Firmer border (`border-2 border-gray-300`) in light mode for clear distinction against the sepia background
- **Title bar**: Theme-aware — light gray in light mode, dark gray in dark mode

### Floating Theme Toggle
- Theme switch icon now floats at top-right (`fixed top-8 right-8`) when scrolled past the header
- Smooth fade+scale entrance animation via Framer Motion's `AnimatePresence`
- Styled consistently with the existing scroll-to-top button

### Table of Contents Sidebar
- Font reduced to `text-sm` (14px) for compact, scannable list
- Links are neutral gray at rest, accent color on hover only
- Progressive bullet styles by nesting level: disc > circle > square
- Tighter vertical spacing and progressive left-margin indentation for nested headings
- Title compacted from `text-xl` to `text-base font-semibold`

### Files Changed
| File | Summary |
|------|---------|
| `app/layout.tsx` | Inter font import, sepia background |
| `app/Main.tsx` | Display font on headings, muted metadata |
| `tailwind.config.js` | Font families, custom primary palette, sepia colors, full typography overrides |
| `components/PageTitle.tsx` | Reduced heading sizes, `font-display` |
| `components/Tag.tsx` | Gray color, removed uppercase |
| `components/ThemeSwitch.tsx` | Floating toggle on scroll |
| `components/sidetoc/TocBody.tsx` | Compact ToC with tiered bullets |
| `css/prism.css` | Light/dark code themes, stronger borders |
| `layouts/PostLayout.tsx` | Prose width constraint, muted metadata |
| `layouts/PostSimple.tsx` | Same |
| `layouts/PostBanner.tsx` | Prose width constraint |
| `layouts/ListLayoutWithTags.tsx` | Muted sidebar tags and metadata |
